### PR TITLE
Fix continuous backup count value

### DIFF
--- a/scripts/informix/check_continuous_backups.j2
+++ b/scripts/informix/check_continuous_backups.j2
@@ -7,7 +7,7 @@
 script_name=$(basename "$0")
 parent_dir="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 
-expected_continuous_backup_process_count="3"
+expected_continuous_backup_process_count="1"
 
 log_file="{{ informix_management_logs_path }}/common/${script_name}.log"
 


### PR DESCRIPTION
Only a single continuous logical log backup process is expected to exist for AIS servers after merging `import_db` and `image_db` databases into the same server. This change corrects the value in the continuous backup script to ensure no errors are generated.